### PR TITLE
Color player names with role color for ghosts

### DIFF
--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -30,6 +30,7 @@ namespace TownOfHost
         {
             return seer == target
                 || target.Is(CustomRoles.GM)
+                || (Main.PlayerStates[seer.Data.PlayerId].IsDead && Options.GhostCanSeeOtherRoles.GetBool()) //seer.Data.IsDead
                 || (seer.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor))
                 || Mare.KnowTargetRoleColor(target, isMeeting);
         }


### PR DESCRIPTION
Colors the names of every player with their role color to ghosts. Visual change that looks nice.

### Preview (shown in Town of Host Edited as it originates from there)

![image](https://github.com/Loonie-Toons/TownOfHost/assets/51543683/d475d9d9-0d3b-4ed1-a7a9-0b195af0065d)
